### PR TITLE
Fixed bug regarding NULL values overrides

### DIFF
--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -32,9 +32,9 @@ class BuilderSpec extends ObjectBehavior {
 
     function it_can_override_default_fixture(BuildableRepositoryInterface $builderRepository)
     {
-        $overrides = ['name' => 'Foobar'];
+        $overrides = ['name' => 'Foobar', 'artist' => null];
 
-        $builderRepository->build('Album', $overrides)->willReturn($overrides);
+        $builderRepository->build('Album', Argument::is($overrides))->willReturn($overrides);
 
         $this->build('Album', $overrides)->shouldReturn($overrides);
     }
@@ -64,6 +64,6 @@ class BuilderSpec extends ObjectBehavior {
 class AlbumStub {
     public function getAttributes()
     {
-       return ['name' => 'Back in Black'];
+       return ['name' => 'Back in Black', 'artist' => 'AC/DC'];
     }
 }

--- a/src/Laracasts/TestDummy/DynamicAttributeReplacer.php
+++ b/src/Laracasts/TestDummy/DynamicAttributeReplacer.php
@@ -47,7 +47,9 @@ class DynamicAttributeReplacer {
 	{
 		foreach ($data as $column => $value)
 		{
-			$data[$column] = $this->updateColumnValue($value);
+			if (is_string($value)) {
+				$data[$column] = $this->updateColumnValue($value);
+			}
 		}
 
 		return $data;


### PR DESCRIPTION
Currently, it is not possibly to override a value and set it to the value `null`, in order to set a nullable field in the database to `NULL`. Instead, will be cast to an empty string while replacing it (with `preg_replace_callback()`). This PR fixes that bug.

I made one of the tests fail due to the bug and wrote a fix for it.
