### PR TITLE
Update Builder.php

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -129,9 +129,9 @@ class Builder {
 	 */
 	protected function mergeFixtureWithOverrides($type, array $fields)
 	{
-		// First, we'll merge the default fixture will any
+		// First, we'll merge the default fixture with any
 		// overrides that the caller provides.
-		$data = array_merge($this->getFixture($type), $fields);
+		$data = array_intersect_key($fields, $this->getFixture($type)) + $this->getFixture($type);
 
 		// Next, we'll do any necessary dynamic replacements.
 		return (new DynamicAttributeReplacer)->replace($data);


### PR DESCRIPTION
Only merge with default fixture those keys in the $fields array that also exist in fixture $type. This is to prevent an Illuminate\Database\QueryException Unknown column error.

Ref: https://github.com/laracasts/TestDummy/issues/19
