### PR TITLE
Mass assignment protection should be re-enabled after record creation with Eloquent driver.

### DIFF
--- a/src/Laracasts/TestDummy/EloquentDatabaseProvider.php
+++ b/src/Laracasts/TestDummy/EloquentDatabaseProvider.php
@@ -29,7 +29,12 @@ class EloquentDatabaseProvider implements BuildableRepositoryInterface {
             throw new TestDummyException("The {$type} model was not found.");
         }
 
-        return new $type($attributes);
+        $object = new $type($attributes);
+
+        // Re-enable mass assignment protection
+        Eloquent::reguard();
+
+        return $object;
     }
 
     /**
@@ -41,6 +46,9 @@ class EloquentDatabaseProvider implements BuildableRepositoryInterface {
     public function save($entity)
     {
         $entity->save();
+
+        // Re-enable mass assignment protection
+        Eloquent::reguard();
     }
 
 }


### PR DESCRIPTION
We ran into a very strange issue in our phpunit tests, where a test would pass if run alone, but would fail when we ran our entire suite.  Eventually we traced it back to the Eloquent::unguard call in the EloquentDatabaseProvide.  Took forever because the TestDummy was used in an entirely different test that ran much earlier than the failing test.

This PR re-enables mass assignment protection after the record is created, which will preserve a more consistent testing environment.
