### PR TITLE
Use Illuminate\Support\Collection when creaing multiple entities

### DIFF
--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -66,7 +66,7 @@ class BuilderSpec extends ObjectBehavior {
         $builderRepository->build(Argument::type('string'), Argument::type('array'))->shouldBeCalledTimes(3)->willReturn($stub);
         $builderRepository->save($stub)->shouldBeCalledTimes(3);
 
-        $this->setTimes(3)->create('Album')->shouldReturn([$stub, $stub, $stub]);
+        $this->setTimes(3)->create('Album')->toArray()->shouldReturn([$stub, $stub, $stub]);
     }
 
 }

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -1,6 +1,7 @@
 <?php namespace Laracasts\TestDummy;
 
 use Symfony\Component\Yaml\Yaml;
+use Illuminate\Support\Collection;
 
 class Builder {
 
@@ -112,7 +113,7 @@ class Builder {
     public function create($type, array $fields = [])
     {
         $times = $this->getTimes();
-        $entities = [];
+        $entities = new Collection;
 
         while ($times --)
         {


### PR DESCRIPTION
Sine you're already requiring Illuminate\Support, why not use its Collection class?

This way we do stuff like:

```
$expected = Faker::times(10)->create('User');

$users = User::all();

$this->assertEquals($users->toArray(), $expected->toArray());
```
