### PR TITLE
Pass the contents of the file to Yaml::parse()

### DIFF
--- a/src/Laracasts/TestDummy/Factory.php
+++ b/src/Laracasts/TestDummy/Factory.php
@@ -84,7 +84,7 @@ class Factory {
 
         $finder = new FixturesFinder($basePath);
 
-        static::$fixtures = Yaml::parse($finder->find());
+        static::$fixtures = Yaml::parse(file_get_contents($finder->find()));
     }
 
     /**


### PR DESCRIPTION
Symfony 2.7 is erroring:

```
The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0. 
Please, pass the contents of the file instead. in 
vendor/symfony/yaml/Symfony/Component/Yaml/Yaml.php on line 58
```
