### PR TITLE
Provide support for packages requiring older versions of illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0",
+        "illuminate/support": "~4.1|~5.0",
         "fzaninotto/faker": "~1.4",
         "symfony/yaml": "~2.0"
     },


### PR DESCRIPTION
Doesn't seem to break anything and fixes https://github.com/laracasts/TestDummy/issues/45. I can now pull in the latest version of TestDummy and use the Faker library :)
