### PR TITLE
Add attributesFor method

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -100,6 +100,18 @@ class Builder {
     }
 
     /**
+     * Build an array of dummy attributes for an entity.
+     *
+     * @param string $name
+     * @param array $attributes
+     * @return array
+     */
+    public function attributesFor($name, $attributes = [])
+    {
+        return $this->mergeFixtureWithOverrides($name, $attributes);
+    }
+
+    /**
      * Build up an entity and populate it with dummy data.
      *
      * @param string $name

--- a/src/Laracasts/TestDummy/Factory.php
+++ b/src/Laracasts/TestDummy/Factory.php
@@ -64,6 +64,18 @@ class Factory {
     }
 
     /**
+     * Build an array of dummy attributes for an entity.
+     *
+     * @param string $name
+     * @param array $attributes
+     * @return array
+     */
+    public static function attributesFor($name, array $attributes = [])
+    {
+        return (new static)->getBuilder()->attributesFor($name, $attributes);
+    }
+
+    /**
      * Fill an entity with test data, without saving it.
      *
      * @param string $name


### PR DESCRIPTION
I've added the `attributesFor()` method, a name I've taken from FactoryGirl in the Ruby world (which also carries the `build` and `create` methods), though you might prefer just `attributes()` or `getAttributes()`.

This simply returns an array of data that would be used to populate an entity, which can be really useful for testing forms. You can easily pass the attributes through a request in one of your controller tests.

Also, sure you could go `Factory::build('Foo')->toArray()` but that's more verbose and requires hitting a database provider which really isn't necessary for just getting entity attributes. Would be a lot nicer to keep it simple!