### PR TITLE
Only check the value for a relationship when the value is a string.

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -204,7 +204,7 @@ class Builder {
      */
     protected function hasRelationshipAttribute($value)
     {
-        if (preg_match('/^factory:(.+)$/i', $value, $matches))
+        if (is_string($value) && preg_match('/^factory:(.+)$/i', $value, $matches))
         {
             return $matches[1];
         }


### PR DESCRIPTION
`$faker->datetime` returns a DateTime object, this causes an error to be thrown when it is passed to `preg_match()` in the `hasRelationshipAttribute()` method.