### PR TITLE
Use `Model:getKey()` for getting the ID for relationships.

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -225,7 +225,7 @@ class Builder {
             return $this->relationshipIds[$relationshipType];
         }
 
-        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType)->id;
+        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType)->getKey();
     }
 
     /**


### PR DESCRIPTION
Not all models will use `id` as the field for the primary key.