### PR TITLE
Call parent tearDown method to allow additional extension

### DIFF
--- a/src/Laracasts/TestDummy/DbTestCase.php
+++ b/src/Laracasts/TestDummy/DbTestCase.php
@@ -30,9 +30,9 @@ class DbTestCase extends TestCase {
 	 */
 	public function tearDown()
 	{
-		parent::tearDown();
-
 		DB::rollback();
+
+		parent::tearDown();
 	}
 
 }

--- a/src/Laracasts/TestDummy/DbTestCase.php
+++ b/src/Laracasts/TestDummy/DbTestCase.php
@@ -30,6 +30,8 @@ class DbTestCase extends TestCase {
 	 */
 	public function tearDown()
 	{
+		parent::tearDown();
+
 		DB::rollback();
 	}
 


### PR DESCRIPTION
Users may want to adjust the `setUp` and `tearDown` steps of their test suite. In the current arrangement, calling `parent::setUp` is required as it needs to make it's way up into Laravel but it allows allows users to customise the set up in their `TestCase`. Adding a parent call for `tearDown` allows users to customise the tear down procedure as well.

I have a possible use case for this - my current test suite often causes a MySQL "too many connections" error when run. If I call `DB::disconnect()` in my `tearDown` I'm able to prevent this from happening. While I don't think it's worth hard-coding this into `DbTestCase` it's important to provide users the option.