### PR TITLE
Allow using closure for attributes

### DIFF
--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -44,6 +44,15 @@ class BuilderSpec extends ObjectBehavior {
         $this->build('Artist')->shouldReturn('foo');
     }
 
+    function it_can_override_defaults_in_a_closure(BuildableRepositoryInterface $builderRepository)
+    {
+        $overrides = [ 'name' => 'The Boogaloos' ];
+
+        $builderRepository->build('Artist', $overrides)->willReturn($overrides);
+
+        $this->build('Artist', $overrides)->shouldReturn($overrides);
+    }
+
     function it_can_persist_an_entity(BuildableRepositoryInterface $builderRepository)
     {
         $albumStub = new AlbumStub;

--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace spec\Laracasts\TestDummy;
+use Faker\Factory as Faker;
 
 use Laracasts\TestDummy\FixturesFinder;
 use PhpSpec\ObjectBehavior;
@@ -15,8 +16,9 @@ class BuilderSpec extends ObjectBehavior {
     function let(BuildableRepositoryInterface $builderRepository)
     {
         $factories = (new Factory(__DIR__.'/helpers'))->factories();
+        $faker = Faker::create();
 
-        $this->beConstructedWith($builderRepository, $factories);
+        $this->beConstructedWith($builderRepository, $factories, $faker);
     }
 
     function it_builds_entities(BuildableRepositoryInterface $builderRepository)
@@ -35,6 +37,12 @@ class BuilderSpec extends ObjectBehavior {
         $this->build('Album', $overrides)->shouldReturn($overrides);
     }
 
+    function it_can_handle_attributes_returned_from_closure(BuildableRepositoryInterface $builderRepository)
+    {
+        $builderRepository->build('Artist', Argument::type('array'))->willReturn('foo');
+
+        $this->build('Artist')->shouldReturn('foo');
+    }
 
     function it_can_persist_an_entity(BuildableRepositoryInterface $builderRepository)
     {

--- a/spec/Laracasts/TestDummy/FactoriesLoaderSpec.php
+++ b/spec/Laracasts/TestDummy/FactoriesLoaderSpec.php
@@ -17,9 +17,10 @@ class FactoriesLoaderSpec extends ObjectBehavior {
         $factories = $this->load(__DIR__.'/helpers');
 
         $factories->shouldBeArray();
-        $factories->shouldHaveCount(1);
+        $factories->shouldHaveCount(2);
         $factories[0]->attributes->shouldHaveKey('name');
         $factories[0]->attributes->shouldHaveKey('artist');
+        $factories[1]->attributes->shouldHaveType('closure');
     }
 
     public function getMatchers()

--- a/spec/Laracasts/TestDummy/helpers/all.php
+++ b/spec/Laracasts/TestDummy/helpers/all.php
@@ -5,7 +5,7 @@ $factory('Album', [
     'artist' => $faker->word
 ]);
 
-$factory('Artist', function ($faker) {
+$factory('Artist', function ($faker, $attributes) {
     return [
         'name' => $faker->name,
     ];

--- a/spec/Laracasts/TestDummy/helpers/all.php
+++ b/spec/Laracasts/TestDummy/helpers/all.php
@@ -5,3 +5,8 @@ $factory('Album', [
     'artist' => $faker->word
 ]);
 
+$factory('Artist', function ($faker) {
+    return [
+        'name' => $faker->name,
+    ];
+});

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -153,7 +153,7 @@ class Builder {
         $factory = $this->getFixture($name)->attributes;
         if (is_callable($factory))
         {
-            $factory = $factory($this->generator);
+            $factory = $factory($this->generator, $attributes);
             if ( ! is_array($factory))
             {
                 throw new TestDummyException("Factory [$name] closure must return an array of attributes.");

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -208,7 +208,7 @@ class Builder {
      */
     protected function hasRelationshipAttribute($value)
     {
-        if (preg_match('/^factory:(.+)$/i', $value, $matches))
+        if (is_string($value) && preg_match('/^factory:(.+)$/i', $value, $matches))
         {
             return $matches[1];
         }

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -229,7 +229,7 @@ class Builder {
             return $this->relationshipIds[$relationshipType];
         }
 
-        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType)->id;
+        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType)->getKey();
     }
 
     /**

--- a/src/Laracasts/TestDummy/Designer.php
+++ b/src/Laracasts/TestDummy/Designer.php
@@ -22,7 +22,7 @@ class Designer {
     {
         // The short name is optional. So we'll do a quick
         // check to make the API as simple as possible to use.
-        if (is_array($shortName))
+        if (is_array($shortName) || is_callable($shortName))
         {
             $attributes = $shortName;
             $shortName = '';

--- a/src/Laracasts/TestDummy/Factory.php
+++ b/src/Laracasts/TestDummy/Factory.php
@@ -1,6 +1,7 @@
 <?php namespace Laracasts\TestDummy;
 
 use Laracasts\TestDummy\BuildableRepositoryInterface as BuildableRepository;
+use Faker\Factory as Faker;
 
 class Factory {
 
@@ -26,15 +27,23 @@ class Factory {
     public static $databaseProvider;
 
     /**
+     * The generator.
+     *
+     * @var Faker
+     */
+    public static $generator;
+
+    /**
      * Create a new factory instance.
      *
      * @param string $factoriesPath
      * @param BuildableRepository $databaseProvider
      */
-    public function __construct($factoriesPath = null, BuildableRepository $databaseProvider = null)
+    public function __construct($factoriesPath = null, BuildableRepository $databaseProvider = null, $generator = null)
     {
         $this->loadFactories($factoriesPath);
         $this->setDatabaseProvider($databaseProvider);
+        $this->setGenerator($generator);
     }
 
     /**
@@ -55,6 +64,16 @@ class Factory {
     public function databaseProvider()
     {
         return static::$databaseProvider;
+    }
+
+    /**
+     * Get the generator.
+     *
+     * @return mixed
+     */
+    public function generator()
+    {
+        return static::$generator;
     }
 
     /**
@@ -99,7 +118,7 @@ class Factory {
      */
     private function getBuilder()
     {
-        return new Builder($this->databaseProvider(), $this->factories());
+        return new Builder($this->databaseProvider(), $this->factories(), $this->generator());
     }
 
     /**
@@ -129,6 +148,20 @@ class Factory {
         if ( ! static::$databaseProvider)
         {
             static::$databaseProvider = $provider ?: new EloquentDatabaseProvider;
+        }
+    }
+
+    /**
+     * Set the generator for random data generation.
+     *
+     * @param  Faker $generator
+     * @return void
+     */
+    private function setGenerator($generator)
+    {
+        if ( ! static::$generator)
+        {
+            static::$generator = $generator ?: Faker::create();
         }
     }
 


### PR DESCRIPTION
The current method of passing in an array of attributes when defining a factory has a major limitation: you can only use scalars or single Faker calls unless you want to wrap them in complicated closures.

This aims to fix that.  Now, instead of an array of attributes you can pass `$factory()` a closure that returns the array.  The closure is passed an instance of the Faker generator that isn't wrapped, so there's no wonky closure business to deal with when using Faker.  This allows the factory to create more complicated fields, such as `$faker->randomElement([ null, $faker->dateTime ])` or `$faker->name . "'s" . $faker->randomElement([ 'Bar', 'Grille' ])` (as mentioned in #59).  

It also provides a way to conditionally fill fields based on data in other fields, which would currently be very cumbersome or impossible.

Some notes:

* #55 and #56 can be closed if this is merged as I included both bug fixes in this branch.
* This fixes #59, or at least provides a way of doing what was desired.
* I didn't much care for adding the Faker generator to the Builder class, but that class seemed like the best place to execute the closure since that's where it's built and where the attributes are retrieved.  I liked the idea of adding a second `$faker` variable with some odd name to the factory loader that's passed to the closure via `use ()` even less.