### PR TITLE
added check for string type when checking for relationships on persist

### DIFF
--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -40,7 +40,7 @@ class BuilderSpec extends ObjectBehavior {
     {
         $albumStub = new AlbumStub;
 
-        $builderRepository->getAttributes(Argument::any())->willReturn([]);
+        $builderRepository->getAttributes(Argument::any())->willReturn([array_keys($albumStub->getAttributes())]);
         $builderRepository->build('Album', Argument::type('array'))->willReturn($albumStub);
         $builderRepository->save($albumStub)->shouldBeCalled();
 
@@ -67,6 +67,6 @@ class BuilderSpec extends ObjectBehavior {
 class AlbumStub {
     public function getAttributes()
     {
-       return ['name' => 'Back in Black', 'artist' => 'AC/DC'];
+       return ['name' => 'Back in Black', 'artist' => 'AC/DC', 'created_at' => new \DateTime('July 21, 1980')];
     }
 }

--- a/spec/Laracasts/TestDummy/BuilderSpec.php
+++ b/spec/Laracasts/TestDummy/BuilderSpec.php
@@ -40,7 +40,7 @@ class BuilderSpec extends ObjectBehavior {
     {
         $albumStub = new AlbumStub;
 
-        $builderRepository->getAttributes(Argument::any())->willReturn([array_keys($albumStub->getAttributes())]);
+        $builderRepository->getAttributes(Argument::any())->willReturn($albumStub->getAttributes());
         $builderRepository->build('Album', Argument::type('array'))->willReturn($albumStub);
         $builderRepository->save($albumStub)->shouldBeCalled();
 

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -208,7 +208,7 @@ class Builder {
      */
     protected function hasRelationshipAttribute($value)
     {
-        if (preg_match('/^factory:(.+)$/i', $value, $matches))
+        if (is_string($value) and preg_match('/^factory:(.+)$/i', $value, $matches))
         {
             return $matches[1];
         }


### PR DESCRIPTION
Same as #55 but with an updated test.

```php
$factory('Album', [
    'name'       => $faker->name,
    'created_at' => $faker->datetime
];
```
Throws the error:
```
warning: preg_match() expects parameter 2 to be string, array given in 
    /path/TestDummy/src/Laracasts/TestDummy/Builder.php line 211
```
This patch adds a quick type check before running `preg_match` to check for a relationship.
   