### PR TITLE
BUGFIX: Should not include files prefix with dot (e.g. `.foo.php.swo`).

### DIFF
--- a/src/Laracasts/TestDummy/FactoriesLoader.php
+++ b/src/Laracasts/TestDummy/FactoriesLoader.php
@@ -22,6 +22,10 @@ class FactoriesLoader {
 
         foreach ((new FactoriesFinder($basePath))->find() as $file)
         {
+            $basename = basename($file);
+            if (substr($basename, 0, 1) === '.') {
+                continue;
+            }
             include($file);
         }
 


### PR DESCRIPTION
When I editing `tests/factories/factories.php` with Vim, a temporary hidden file like `.factories.php.swp` will auto-generated and delete later by Vim, but TestDummy will also include the temporary file and that will print out content of temporary file.

This pull request will limited TestDummy ONLY include files that base name do not leading by dot.