### PR TITLE
Always return the collection of items on create.

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -129,7 +129,7 @@ class Builder {
             return $this->persist($name, $attributes);
         }, range(1, $this->getTimes()));
 
-        return count($entities) > 1 ? new Collection($entities) : $entities[0];
+        return  new Collection($entities);
     }
 
     /**


### PR DESCRIPTION
Always return the collection of items on create so that it is easy for testing the models with laravel collection items. In laravel when creating the models they return Collection items back whether the count is 1 or not.