### PR TITLE
Bug reintroduced with recent commit

### DIFF
--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -171,7 +171,7 @@ class Builder
 
         $factory = $this->triggerFakerOnAttributes($factory);
 
-        return array_merge($factory, $attributes);
+        return array_intersect_key($attributes, $factory) + $factory;
     }
 
     /**


### PR DESCRIPTION
mergeFixtureWithOverrides was updated to use array_merge with the attributes. This was the original behavior in v1.0 and resulted in throwing Illuminate\Database\QueryException Unknown column errors. This bug was fixed in https://github.com/laracasts/TestDummy/pull/29 but it was recently changed back in https://github.com/laracasts/TestDummy/commit/e21fedc5ed56922549e6a4926b24be8f4b3f8ead to "Allow overriding fields not defined in a factory". For me, the better solution to that problem would be to just add the fields to the factory.

This PR reverts back to the working version.

fixes: https://github.com/laracasts/TestDummy/issues/77