### PR TITLE
Allow overriding relationship attributes using dot notation syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: vendor/bin/phpspec run
+script: vendor/bin/phpspec run && phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,18 @@
         "fzaninotto/faker": "~1.4"
     },
     "require-dev": {
-        "phpspec/phpspec": "~2.0"
+        "phpspec/phpspec": "~2.0",
+        "illuminate/database": "~4.0|~5.0"
     },
     "autoload": {
         "psr-0": {
             "Laracasts\\TestDummy": "src/"
         }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/IntegrationTestCase.php"
+        ]
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "autoload-dev": {
         "classmap": [
-            "tests/IntegrationTestCase.php"
+            "tests/IntegrationTestCase.php",
+            "tests/models"
         ]
     },
     "minimum-stability": "dev"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
+            <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -2,11 +2,6 @@
 
 use Illuminate\Support\Collection;
 
-function ddd() {
-    call_user_func_array('var_dump', func_get_args());
-    exit;
-}
-
 class Builder
 {
 

--- a/src/Laracasts/TestDummy/Builder.php
+++ b/src/Laracasts/TestDummy/Builder.php
@@ -2,6 +2,11 @@
 
 use Illuminate\Support\Collection;
 
+function ddd() {
+    call_user_func_array('var_dump', func_get_args());
+    exit;
+}
+
 class Builder
 {
 
@@ -207,14 +212,13 @@ class Builder
     protected function persist($name, array $attributes = [])
     {
         $entity = $this->build($name, $attributes);
-        $databaseAttributes = $this->database->getAttributes($entity);
 
         // We'll filter through all of the columns, and check
         // to see if there are any defined relationships. If there
         // are, then we'll need to create those records as well.
-        foreach ($databaseAttributes as $columnName => $value) {
+        foreach ($this->database->getAttributes($entity) as $columnName => $value) {
             if ($relationship = $this->hasRelationshipAttribute($value)) {
-                $entity[$columnName] = $this->fetchRelationship($relationship, $attributes);
+                $entity[$columnName] = $this->fetchRelationship($relationship);
             }
         }
 
@@ -244,13 +248,13 @@ class Builder
      * @param  string $relationshipType
      * @return integer
      */
-    protected function fetchRelationship($relationshipType, $attributes)
+    protected function fetchRelationship($relationshipType)
     {
         if ($this->isRelationshipAlreadyCreated($relationshipType)) {
             return $this->relationshipIds[$relationshipType];
         }
 
-        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType, $attributes)->getKey();
+        return $this->relationshipIds[$relationshipType] = $this->persist($relationshipType)->getKey();
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Laracasts\TestDummy\Factory;
+
+class FaktoryCreateTest extends IntegrationTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        Factory::$factoriesPath = __DIR__ . '/factories';
+    }
+
+    /** @test */
+    public function it_can_create_override_attributes_while_there_is_a_defined_relationship()
+    {
+        $user = Factory::create('user_with_role', [
+            'email' => 'example@example.com',
+            'password' => 'my-secret-password',
+        ]);
+
+        $this->assertEquals('example@example.com', $user->email);
+        $this->assertEquals('my-secret-password', $user->password);
+        $this->assertInstanceOf('Role', $user->role);
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -21,6 +21,34 @@ class FaktoryCreateTest extends IntegrationTestCase
 
         $this->assertEquals('example@example.com', $user->email);
         $this->assertEquals('my-secret-password', $user->password);
-        $this->assertInstanceOf('Role', $user->role);
+        $this->assertInstanceOf('Acme\Role', $user->role);
+    }
+
+    /** @test */
+    public function relationship_attributes_can_be_overridden_using_dot_notation_for_named_factories()
+    {
+        $user = Factory::create('user_with_role', [
+            'email' => 'example@example.com',
+            'password' => 'my-secret-password',
+            'role.display_name' => 'role-name',
+        ]);
+
+        $this->assertEquals('example@example.com', $user->email);
+        $this->assertEquals('my-secret-password', $user->password);
+        $this->assertEquals('role-name', $user->role->display_name);
+    }
+
+    /** @test */
+    public function relationship_attributes_can_be_overridden_using_dot_notation_for_namespaced_factories()
+    {
+        $user = Factory::create('Acme\User', [
+            'email' => 'example@example.com',
+            'password' => 'my-secret-password',
+            'Acme\Role.display_name' => 'role-name',
+        ]);
+
+        $this->assertEquals('example@example.com', $user->email);
+        $this->assertEquals('my-secret-password', $user->password);
+        $this->assertEquals('role-name', $user->role->display_name);
     }
 }

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -53,19 +53,3 @@ abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
         });
     }
 }
-
-class User extends Illuminate\Database\Eloquent\Model
-{
-    public function role()
-    {
-        return $this->belongsTo('Role');
-    }
-}
-
-class Role extends Illuminate\Database\Eloquent\Model
-{
-    public function users()
-    {
-        return $this->hasMany('User');
-    }
-}

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->configureDatabase();
+        $this->migrate();
+    }
+
+    protected function configureDatabase()
+    {
+        $db = new DB;
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+            ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    protected function migrate()
+    {
+        $this->migrateUsersTable();
+        $this->migrateRolesTable();
+    }
+
+
+    protected function migrateUsersTable()
+    {
+        DB::schema()->create('users', function($table)
+        {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->integer('role_id')->unsigned();
+            $table->timestamps();
+        });
+    }
+
+    protected function migrateRolesTable()
+    {
+        DB::schema()->create('roles', function($table)
+        {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('display_name');
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+}
+
+class User extends Illuminate\Database\Eloquent\Model
+{
+    public function role()
+    {
+        return $this->belongsTo('Role');
+    }
+}
+
+class Role extends Illuminate\Database\Eloquent\Model
+{
+    public function users()
+    {
+        return $this->hasMany('User');
+    }
+}

--- a/tests/factories/factories.php
+++ b/tests/factories/factories.php
@@ -1,0 +1,18 @@
+<?php
+
+$factory('User', 'user_with_role', [
+    'name' => $faker->name,
+    'email' => $faker->email,
+    'password' => $faker->word,
+    'role_id' => 'factory:role',
+    'created_at' => $faker->date(),
+    'updated_at' => $faker->date()
+]);
+
+$factory('Role', 'role', [
+    'name' => $faker->name,
+    'display_name' => $faker->name,
+    'description' => $faker->sentence(),
+    'created_at' => $faker->date(),
+    'updated_at' => $faker->date()
+]);

--- a/tests/factories/factories.php
+++ b/tests/factories/factories.php
@@ -1,6 +1,23 @@
 <?php
 
-$factory('User', 'user_with_role', [
+$factory('Acme\User', [
+    'name' => $faker->name,
+    'email' => $faker->email,
+    'password' => $faker->word,
+    'role_id' => 'factory:Acme\Role',
+    'created_at' => $faker->date(),
+    'updated_at' => $faker->date()
+]);
+
+$factory('Acme\Role', [
+    'name' => $faker->name,
+    'display_name' => $faker->name,
+    'description' => $faker->sentence(),
+    'created_at' => $faker->date(),
+    'updated_at' => $faker->date()
+]);
+
+$factory('Acme\User', 'user_with_role', [
     'name' => $faker->name,
     'email' => $faker->email,
     'password' => $faker->word,
@@ -9,7 +26,7 @@ $factory('User', 'user_with_role', [
     'updated_at' => $faker->date()
 ]);
 
-$factory('Role', 'role', [
+$factory('Acme\Role', 'role', [
     'name' => $faker->name,
     'display_name' => $faker->name,
     'description' => $faker->sentence(),

--- a/tests/models/Acme/Role.php
+++ b/tests/models/Acme/Role.php
@@ -1,0 +1,9 @@
+<?php namespace Acme;
+
+class Role extends \Illuminate\Database\Eloquent\Model
+{
+    public function users()
+    {
+        return $this->hasMany('Acme\User');
+    }
+}

--- a/tests/models/Acme/User.php
+++ b/tests/models/Acme/User.php
@@ -1,0 +1,9 @@
+<?php namespace Acme;
+
+class User extends \Illuminate\Database\Eloquent\Model
+{
+    public function role()
+    {
+        return $this->belongsTo('Acme\Role');
+    }
+}


### PR DESCRIPTION
As discussed in #82, this adds support for overriding relationship attributes using dot notation. It works for classname-named factories as well as shortnamed factories.

Given these factories:

```php
$factory('Acme\User', 'user_with_role', [
    'email' => $faker->email,
    'password' => $faker->word,
    'role_id' => 'factory:role',
]);

$factory('Acme\Role', 'role', [
    'display_name' => $faker->name,
]);
```

You can do this:

```php
$user = Factory::create('user_with_role', [
    'email' => 'example@example.com',
    'password' => 'my-secret-password',
    'role.display_name' => 'role-name',
]);
```

Still needs doc blocks, and likely can clean up how I'm filtering out the attributes. Disappointed array_filter doesn't pass keys :(

Will comment when I think it's ready to be merged, happy to discuss what's here in the mean time.