### PR TITLE
Support overriding relationship attributes

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -80,7 +80,7 @@ class Builder
      *
      * @param  string $name
      * @param  array  $overrides
-     * @return array
+     * @return mixed
      */
     public function build($name, $overrides = [])
     {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -229,6 +229,7 @@ class Builder
      * Prepare and assign any applicable relationships.
      *
      * @param  mixed $entity
+     * @param  array $attributes
      * @return mixed
      */
     protected function assignRelationships($entity, $attributes)

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -180,4 +180,18 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         assertEquals('Overridden Post Title', $comment->post->title);
         assertEquals('Overridden Author Name', $comment->post->author->name);
     }
+
+    /**
+     * @test
+     */
+    public function relationship_overrides_are_ignored_if_the_relationship_is_not_actually_defined()
+    {
+        $comment = TestDummy::create('Comment', [
+            'post_id' => 1,
+            'post_id.title' => 'override'
+        ]);
+
+        assertNull($comment->post);
+        assertNull($comment->getAttribute('post_id.title'));
+    }
 }

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -5,10 +5,16 @@ $factory('Post', 'scheduled_post', [
 ]);
 
 $factory('Post', [
+    'author_id' => 'factory:Person',
     'title' => 'Post Title'
 ]);
 
 $factory('Comment', [
+    'post_id' => 'factory:Post',
+    'body' => $faker->word
+]);
+
+$factory('Comment', 'comment_for_post_by_person', [
     'post_id' => 'factory:Post',
     'body' => $faker->word
 ]);
@@ -18,3 +24,13 @@ $factory('Foo', function($faker) {
         'name' => $faker->word
     ];
 });
+
+$factory('Message', [
+    'contents' => $faker->sentence,
+    'sender_id' => 'factory:Person',
+    'receiver_id' => 'factory:Person',
+]);
+
+$factory('Person', [
+    'name' => $faker->name
+]);

--- a/tests/support/models/Message.php
+++ b/tests/support/models/Message.php
@@ -1,0 +1,8 @@
+<?php
+
+use \Illuminate\Database\Eloquent\Model;
+
+class Message extends Model {
+    public function sender() { return $this->belongsTo('Person', 'sender_id'); }
+    public function receiver() { return $this->belongsTo('Person', 'receiver_id'); }
+}

--- a/tests/support/models/Person.php
+++ b/tests/support/models/Person.php
@@ -1,0 +1,5 @@
+<?php
+
+use \Illuminate\Database\Eloquent\Model;
+
+class Person extends Model {}

--- a/tests/support/models/Post.php
+++ b/tests/support/models/Post.php
@@ -4,4 +4,5 @@ use \Illuminate\Database\Eloquent\Model;
 
 class Post extends Model {
     public function comments() { return $this->hasMany('Comment'); }
+    public function author() { return $this->belongsTo('Person', 'author_id'); }
 }


### PR DESCRIPTION
This PR adds support for overriding relationship attributes.

### TL;DR

Given the following factories:

```php
$factory('Post', [
    'title' => 'Post Title'
]);

$factory('Comment', [
    'post_id' => 'factory:Post',
    'body' => $faker->word
]);
```

...you can override a `Post` title using the following syntax:

```php
$comment = Factory::create('Comment', [
    'post_id.title' => 'override'
]);
```
The column name was chosen as the attribute prefix to allow separately overriding relationships that use the same factory, as it's the only reliable unique identifier for the relationship. See below for an example.

### More fun

**Nested relationships**

This PR supports relationships of arbitrary nesting level. Given these factories:

```php
$factory('Person', [
    'name' => $faker->name
]);

$factory('Post', [
    'author_id' => 'factory:Person',
    'title' => 'Post Title'
]);

$factory('Comment', 'comment_for_post_by_person', [
    'post_id' => 'factory:Post',
    'body' => $faker->word
]);
```

...you can override nested relationship attributes like so:

```php
$comment = Factory::create('comment_for_post_by_person', [
    'body' => 'Overridden Comment Body',
    'post_id.title' => 'Overridden Post Title',
    'post_id.author_id.name' => 'Overridden Author Name',
]);
```

**Multiple relationships using the same factory**

If you have an object that has two relationships to the same type of model but under different keys, you can still override their attributes separately.

Consider these factories:

```php
$factory('Message', [
    'contents' => $faker->sentence,
    'sender_id' => 'factory:Person',
    'receiver_id' => 'factory:Person',
]);

$factory('Person', [
    'name' => $faker->name
]);
```

Since I've opted to use the column name as the identifier for the relationship, you can easily override those attributes separately like so:

```php
$message = Factory::create('Message', [
    'sender_id.name' => 'Adam',
    'receiver_id.name' => 'Jeffrey',
]);
```

> Note: This is the reason for removing the `relationshipIds` caching that was happening previously. There is no way to treat the relationships as independent when using the ID caching. I think the performance hit is negligible.

### Crappy parts

I needed to add the `filterArrayKeys` helper because PHP < 5.6 doesn't allow filtering an array by key and it's an annoying enough operation that duplicating it would be unfortunate. It would be nice to just create an `array_filter_keys` function and autoload it in some sort of helpers file because it definitely feels out of place in the `Builder` class, but I didn't want to make that decision alone.