### PR TITLE
Allow short name of an existing function

### DIFF
--- a/src/Designer.php
+++ b/src/Designer.php
@@ -23,9 +23,13 @@ class Designer
      */
     public function define($name, $shortName = '', $attributes = [])
     {
+        // The short name may be a closure, is_callable() is not sufficient
+        // because the short name might be the name of an existing function
+        $shortNameIsAClosure = (is_callable($shortName) && !is_string($shortName));
+
         // The short name is optional. So we'll do a quick
         // check to make the API as simple as possible to use.
-        if (is_array($shortName) || is_callable($shortName)) {
+        if (is_array($shortName) || $shortNameIsAClosure) {
             $attributes = $shortName;
             $shortName = '';
         }

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -1,5 +1,19 @@
 <?php
 
+/**
+ * This function has the same name as the fixture `scheduled_post` and MUST NOT be called
+ * Fixtures with short name should be allowed to use the name of an existing function
+ *
+ * @throws Exception
+ */
+function scheduled_post()
+{
+    throw new \Exception(
+        'Function `scheduled_post()` MUST NOT be called. ' .
+        'Fixture with a short name of an existing function should be allowed.'
+    );
+}
+
 $factory('Post', 'scheduled_post', [
     'title' => 'Scheduled Post Title'
 ]);


### PR DESCRIPTION
Made this fix because I used this library with Laravel and it's shipped with tons of helpers such as the function `post()`.

My fixtures have a factory called `post` which will call the existing `post()` function. And it should have not.