### PR TITLE
get sub-arrays for 'attributesFor'

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -221,15 +221,8 @@ class Builder
         // So we can now filter through our attributes and call these
         // closures, which will generate the proper Faker values.
 
-        return array_map(function ($attribute) {
-            if ($attribute instanceof Closure) {
-                $attribute = $attribute();
-            }
 
-            // It's possible that the called Faker method returned an array.
-            // If that is the case, we'll implode it for the user.
-
-            return array_map([$this,'runFaker'], $attributes);
+	return array_map([$this,'runFaker'], $attributes);
     }
     
 	/**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -239,7 +239,7 @@ class Builder
 	 *
 	 * @return array|string
 	 */
-	private function runFaker($attribute)
+	protected function runFaker($attribute)
 	{
 		if ($attribute instanceof Closure) {
 			$attribute = $attribute();

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -229,9 +229,40 @@ class Builder
             // It's possible that the called Faker method returned an array.
             // If that is the case, we'll implode it for the user.
 
-            return is_array($attribute) ? implode(' ', $attribute) : $attribute;
-        }, $attributes);
+            return array_map([$this,'runFaker'], $attributes);
     }
+    
+	/**
+	 * Apply Faker dummy values.
+	 *
+	 * @param $attribute
+	 *
+	 * @return array|string
+	 */
+	private function runFaker($attribute)
+	{
+		if ($attribute instanceof Closure) {
+			$attribute = $attribute();
+		}
+
+		// It's possible that the called Faker method returned an array.
+		// If that is the case, we'll implode it for the user.
+		if (is_array($attribute)) {
+
+			// If $attribute is associative array
+			if (array_values($attribute) !== $attribute) {
+				return array_map([
+						$this,
+						'runfaker'
+				], $attribute);
+			} else {
+				return implode(' ',
+						$attribute);
+			}
+		} else {
+			return $attribute;
+		}
+	}
 
     /**
      * Get a Faker instance.


### PR DESCRIPTION
this
```php
$factory('Album', [
    'name' => 'Rock or Bust',
    'artist' => 'AC/DC'
]);
```
works fine for form
```html
<input type="text" name="name" />
<input type="text" name="artist" />
```
but not for this
```php
$factory('Album', [
    'name' => 'Rock or Bust',
    'artist' => ['name'=>'AC/DC','genre'=>'rock','email'=>'acdc@rock.com']
]);
```
```html
<input name="name" />
<input name="artist[name]" />
<input name="artist[genre]" />
<input name="artist[email]" />
```
this PR handles these sub arrays in populating form html.