### PR TITLE
FactoriesFinder should be able to ignore files without extension.

### DIFF
--- a/spec/Laracasts/TestDummy/FactoriesFinderSpec.php
+++ b/spec/Laracasts/TestDummy/FactoriesFinderSpec.php
@@ -7,9 +7,13 @@ use Prophecy\Argument;
 
 class FactoriesFinderSpec extends ObjectBehavior
 {
+	private $stubDir;
+
 	function let()
 	{
-		$this->beConstructedWith(__DIR__.'/helpers');
+		$this->stubDir = __DIR__.'/helpers/';
+
+		$this->beConstructedWith($this->stubDir);
 	}
 
 	function it_is_initializable()
@@ -19,20 +23,37 @@ class FactoriesFinderSpec extends ObjectBehavior
 
 	function it_hunts_down_the_fixtures_file_like_a_dog()
 	{
-		$this->find()->shouldBe([__DIR__.'/helpers/all.php']);
+		$this->find()->shouldBe([$this->stubDir.'all.php']);
 	}
 
 	function it_ignores_non_php_files()
 	{
-		$dir = __DIR__.'/helpers';
-		$notPhpFile = $dir .'/foo.txt';
+		$notPhpFile = $this->createFile('foo.txt');
 
-		// We'll create a file that should not be included...
-		file_put_contents($notPhpFile, '');
-
-		$this->find()->shouldBe([$dir.'/all.php']);
+		$this->find()->shouldBe([$this->stubDir.'all.php']);
 
 		unlink($notPhpFile);
 	}
 
+	function it_ignores_files_without_extension()
+	{
+		$fileWithoutExtension = $this->createFile('foo');
+
+		$this->find()->shouldBe([$this->stubDir.'all.php']);
+
+		unlink($fileWithoutExtension);
+	}
+
+	private function createFile($filename, $dir = null, $content = '')
+	{
+		if ($dir === null) {
+			$dir = $this->stubDir;
+		}
+
+		$file = $dir . $filename;
+
+		file_put_contents($file, $content);
+
+		return $file;
+	}
 }

--- a/src/FactoriesFinder.php
+++ b/src/FactoriesFinder.php
@@ -64,7 +64,9 @@ class FactoriesFinder
      */
     private function getExtension($file)
     {
-        return isset(pathinfo($file)['extension']) ? pathinfo($file)['extension'] : null;
+        $fileInfo = pathinfo($file);
+
+        return isset($fileInfo['extension']) ? $fileInfo['extension'] : null;
     }
 
 }

--- a/src/FactoriesFinder.php
+++ b/src/FactoriesFinder.php
@@ -35,9 +35,7 @@ class FactoriesFinder
         $files = [];
 
         foreach ($this->getDirectoryIterator() as $file) {
-            $extension = pathinfo($file)['extension'];
-
-            if ($extension !== 'php') continue;
+            if ($this->getExtension($file) !== 'php') continue;
 
             $files[] = $file->getPathname();
         }
@@ -56,6 +54,17 @@ class FactoriesFinder
         $directoryIterator->setFlags(RecursiveDirectoryIterator::SKIP_DOTS);
 
         return new RecursiveIteratorIterator($directoryIterator);
+    }
+
+    /**
+     * Get the extension of a file.
+     *
+     * @param $file
+     * @return string|null
+     */
+    private function getExtension($file)
+    {
+        return isset(pathinfo($file)['extension']) ? pathinfo($file)['extension'] : null;
     }
 
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -4,6 +4,8 @@ use Laracasts\TestDummy\Factory as TestDummy;
 
 use Illuminate\Database\Capsule\Manager as DB;
 
+require 'vendor/phpunit/phpunit/src/Framework/Assert/Functions.php';
+
 class FactoryTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()


### PR DESCRIPTION
I have come across this issue, when using SVN (sigh, I know) FactoriesFinder throws an error related to missing extension for `entries` file. This fixes the issue.