### PR TITLE
Add a EloquentPivotModel database provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ array(4) {
 $post = Factory::attributesFor('Post');
 ```
 
-The difference between `build()` and `attributesFor()` is that the former will return an instance of the given model type (such as `Post`). The latter will simply return an array of the generated attributes, which can be useful in some situations. 
+The difference between `build()` and `attributesFor()` is that the former will return an instance of the given model type (such as `Post`). The latter will simply return an array of the generated attributes, which can be useful in some situations.
 
 ### Build and persist a song entity.
 
@@ -211,6 +211,15 @@ use Laracasts\TestDummy\Factory;
 $adminUser = Factory::create('admin_user');
 ```
 
+#### Custom Pivot Models
+
+If your model is a [Custom Pivot Model](http://laravel.com/docs/5.0/eloquent#working-with-pivot-tables) use TestDummy's EloquentPivotModel provider and pass through the pivot models parent and the pivot table name.
+
+```
+Factory::$databaseProvider = new Laracasts\TestDummy\EloquentPivotModel(new Post, 'post_tags');
+Factory::create('PostTag');
+```
+
 #### Defining with Closures
 
 Alternatively, you may pass a closure as the second argument to the `$factory` method. This can be useful for situations where you need a bit more control over the values that you assign to each attribute. Here's an example:
@@ -218,7 +227,7 @@ Alternatively, you may pass a closure as the second argument to the `$factory` m
 ```php
 $factory('App\Artist', function($faker) {
     $name = sprintf('Some Band Named %s', $faker->word);
-    
+
     return [
         'name' => $name
     ];

--- a/src/EloquentPivotModel.php
+++ b/src/EloquentPivotModel.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Laracasts\TestDummy;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class EloquentPivotModel implements IsPersistable {
+
+    /**
+     * @var Eloquent
+     */
+    protected $parent;
+
+    /**
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Constructor.
+     *
+     * @param Eloquent $parent
+     * @param string   $table
+     */
+    public function __construct(Eloquent $parent, $table)
+    {
+        $this->parent = $parent;
+        $this->table = $table;
+    }
+
+    /**
+     * Build the entity with attributes.
+     *
+     * @param  string $type
+     * @param  array  $attributes
+     * @throws TestDummyException
+     * @return Eloquent
+     */
+    public function build($type, array $attributes)
+    {
+        if ( ! class_exists($type)) {
+            throw new TestDummyException("The {$type} model was not found.");
+        }
+
+        return $this->fill($type, $attributes);
+    }
+
+    /**
+     * Persist the entity.
+     *
+     * @param  Model $entity
+     * @return void
+     */
+    public function save($entity)
+    {
+        $entity->save();
+    }
+
+    /**
+     * Get all attributes for the model.
+     *
+     * @param  object $entity
+     * @return array
+     */
+    public function getAttributes($entity)
+    {
+        return $entity->getAttributes();
+    }
+
+    /**
+     * Force fill an object with attributes.
+     *
+     * @param  string $type
+     * @param  array  $attributes
+     * @return Model
+     */
+    private function fill($type, $attributes)
+    {
+        Eloquent::unguard();
+
+        $model = new $type($this->parent, $attributes, $this->table, $exists = false);
+
+        Eloquent::reguard();
+
+        return $model;
+    }
+
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -64,8 +64,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $attributes = TestDummy::build('Post');
 
-        assertInstanceOf('Post', $attributes);
-        assertEquals('Post Title', $attributes->title);
+        $this->assertInstanceOf('Post', $attributes);
+        $this->assertEquals('Post Title', $attributes->title);
     }
 
     /** @test */
@@ -73,7 +73,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::build('Post', ['title' => 'override']);
 
-        assertEquals('override', $post->title);
+        $this->assertEquals('override', $post->title);
     }
 
     /** @test */
@@ -81,7 +81,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::build('scheduled_post');
 
-        assertInstanceOf('Post', $post);
+        $this->assertInstanceOf('Post', $post);
     }
 
     /** @test */
@@ -89,11 +89,11 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $comments = TestDummy::times(2)->create('Comment');
 
-        assertInstanceOf('Comment', $comments[0]);
-        assertInternalType('string', $comments[0]->body);
+        $this->assertInstanceOf('Comment', $comments[0]);
+        $this->assertInternalType('string', $comments[0]->body);
 
         // Faker should produce a unique value for each generation.
-        assertNotEquals($comments[0]->body, $comments[1]->body);
+        $this->assertNotEquals($comments[0]->body, $comments[1]->body);
     }
 
     /** @test */
@@ -101,8 +101,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $attributes = TestDummy::attributesFor('Post', ['title' => 'override']);
 
-        assertInternalType('array', $attributes);
-        assertEquals('override', $attributes['title']);
+        $this->assertInternalType('array', $attributes);
+        $this->assertEquals('override', $attributes['title']);
     }
 
     /** @test */
@@ -110,8 +110,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::create('Post');
 
-        assertInstanceOf('Post', $post);
-        assertNotNull($post->id);
+        $this->assertInstanceOf('Post', $post);
+        $this->assertNotNull($post->id);
     }
 
     /** @test */
@@ -119,8 +119,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $comment = TestDummy::create('Comment');
 
-        assertInstanceOf('Comment', $comment);
-        assertInstanceOf('Post', $comment->post);
+        $this->assertInstanceOf('Comment', $comment);
+        $this->assertInstanceOf('Post', $comment->post);
     }
 
     /** @test */
@@ -128,8 +128,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $posts = TestDummy::times(3)->create('Post');
 
-        assertInstanceOf('Illuminate\Support\Collection', $posts);
-        assertCount(3, $posts);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $posts);
+        $this->assertCount(3, $posts);
     }
 
     /**
@@ -154,7 +154,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.title' => 'override'
         ]);
 
-        assertEquals('override', $comment->post->title);
+        $this->assertEquals('override', $comment->post->title);
     }
 
     /** @test */
@@ -165,8 +165,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'receiver_id.name' => 'Jeffrey',
         ]);
 
-        assertEquals('Adam', $message->sender->name);
-        assertEquals('Jeffrey', $message->receiver->name);
+        $this->assertEquals('Adam', $message->sender->name);
+        $this->assertEquals('Jeffrey', $message->receiver->name);
     }
 
     /** @test */
@@ -178,9 +178,9 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.author_id.name' => 'Overridden Author Name',
         ]);
 
-        assertEquals('Overridden Comment Body', $comment->body);
-        assertEquals('Overridden Post Title', $comment->post->title);
-        assertEquals('Overridden Author Name', $comment->post->author->name);
+        $this->assertEquals('Overridden Comment Body', $comment->body);
+        $this->assertEquals('Overridden Post Title', $comment->post->title);
+        $this->assertEquals('Overridden Author Name', $comment->post->author->name);
     }
 
     /** @test */
@@ -191,8 +191,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.title' => 'override'
         ]);
 
-        assertNull($comment->post);
-        assertNull($comment->getAttribute('post_id.title'));
+        $this->assertNull($comment->post);
+        $this->assertNull($comment->getAttribute('post_id.title'));
     }
 }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -57,6 +57,18 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             $table->string('contents');
             $table->timestamps();
         });
+
+        DB::schema()->create('tags', function ($table) {
+            $table->increments('id');
+            $table->string('tag');
+            $table->timestamps();
+        });
+
+        DB::schema()->create('post_tags', function ($table) {
+            $table->increments('id');
+            $table->integer('post_id')->unsigned();
+            $table->integer('tag_id')->unsigned();
+        });
     }
 
     /** @test */
@@ -193,6 +205,17 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
         $this->assertNull($comment->post);
         $this->assertNull($comment->getAttribute('post_id.title'));
+    }
+
+    /** @test */
+    public function it_uses_a_pivot_model()
+    {
+        $parent = new Post;
+        TestDummy::$databaseProvider = new Laracasts\TestDummy\EloquentPivotModel($parent, 'post_tags');
+
+        $postTag = TestDummy::create('PostTag');
+
+        $this->assertInstanceOf('PostTag', $postTag);
     }
 }
 

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -39,3 +39,12 @@ $factory('Message', [
 $factory('Person', [
     'name' => $faker->name
 ]);
+
+$factory('Tag', [
+    'tag' => $faker->name
+]);
+
+$factory('PostTag', [
+    'post_id' => '1',
+    'tag_id'  => '1'
+]);

--- a/tests/support/models/Post.php
+++ b/tests/support/models/Post.php
@@ -5,4 +5,5 @@ use \Illuminate\Database\Eloquent\Model;
 class Post extends Model {
     public function comments() { return $this->hasMany('Comment'); }
     public function author() { return $this->belongsTo('Person', 'author_id'); }
+    public function tags() { return $this->belongsToMany('Tag'); }
 }

--- a/tests/support/models/PostTag.php
+++ b/tests/support/models/PostTag.php
@@ -1,0 +1,7 @@
+<?php
+
+use \Illuminate\Database\Eloquent\Relations\Pivot;
+
+class PostTag extends Pivot {
+
+}

--- a/tests/support/models/Tag.php
+++ b/tests/support/models/Tag.php
@@ -1,0 +1,7 @@
+<?php
+
+use \Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model {
+    public function posts() { return $this->belongsToMany('Post'); }
+}


### PR DESCRIPTION
I had a situation where I need to use a custom pivot model and I was not able to populate the associated table with TestDummy. This database provider just provides the user the ability to use TestDummy per normal as long as they set the EloquentPivotModel provider first and pass to it a parent of the pivot and the pivot table name.
```
Factory::$databaseProvider = new Laracasts\TestDummy\EloquentPivotModel(new Post, 'post_tags');
Factory::create('PostTag');
```
fyi: good info on custom pivot models can be found here
https://github.com/laravel/framework/issues/2093#issuecomment-39154456

ps: you will notice in test/support/factories/factories that I've hard coded the post_id and tag_id 's values. This is because otherwise I was getting a `Argument 1 passed to Illuminate\Database\Eloquent\Model::__construct() must be of the type array, object given, called in /Users/Locutus/Sites/TestDummy/src/EloquentPivotModel.php on line 81 and defined` error when using 'factory:Post'. For some reason the Post factory was not being created and I got fed up with it. However it does work as expected in my production app.