### PR TITLE
Ability to use existing data

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -150,7 +150,7 @@ class Builder
         return $this->model->random($class, $attributes);
     }
 
-    protected function exists($name, $attributes)
+    public function exists($name, $attributes)
     {
         $entity = $this->random($name, $attributes);
 
@@ -158,14 +158,6 @@ class Builder
         $this->model->save($entity);
 
         return $entity;
-    }
-
-    protected function existingIndex($name)
-    {
-        $indices = $this->model->allIndices($name);
-        $rand = mt_rand(0, count($indices)-1);
-        $index = $indices[$rand];
-        return $index;
     }
 
     /**
@@ -355,7 +347,7 @@ class Builder
                 break;
             case 'model:':
                 $attributes = $this->extractRelationshipAttributes($relationshipName, $attributes);
-                $relationKey = $this->existingIndex($factoryName[1]);
+                $relationKey = $this->exists($factoryName[1], $attributes)->getKey();
                 break;
             default:
                 throw new \Exception('Relation identifier not allowed. Please use model or factory.');

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -139,6 +139,15 @@ class Builder
         return $entity;
     }
 
+    /**
+     * Fetch a random existing entity, or create a new one
+     *
+     * @param $name
+     * @param $overrides
+     * @param array $existingKeys
+     * @return mixed
+     * @throws TestDummyException
+     */
     protected function random($name, $overrides, array $existingKeys = [])
     {
         $attributes = $this->getAttributes($name, $overrides);
@@ -150,6 +159,13 @@ class Builder
         return $this->model->random($class, $attributes, $existingKeys);
     }
 
+    /**
+     * Assign relationships to a randomly fetched entity
+     * @param $name
+     * @param $attributes
+     * @param array $existingKeys
+     * @return mixed
+     */
     public function exists($name, $attributes, array $existingKeys = [])
     {
         $entity = $this->random($name, $attributes, $existingKeys);
@@ -323,7 +339,6 @@ class Builder
     protected function findRelation($attribute)
     {
         if (is_string($attribute) && (preg_match('/^factory:(.+)$/i', $attribute, $matches) || preg_match('/^model:(.+)$/i', $attribute, $matches))) {
-//            return $matches[1];
             return $matches;
         }
 
@@ -336,7 +351,9 @@ class Builder
      * @param  string $factoryName
      * @param  string $relationshipName
      * @param  array  $attributes
+     * @param  array  $existingKeys
      * @return int
+     * @throws \Exception
      */
     protected function fetchRelationId($factoryName, $relationshipName, array $attributes, array $existingKeys)
     {
@@ -354,8 +371,6 @@ class Builder
             default:
                 throw new \Exception('Relation identifier not allowed. Please use model or factory.');
         }
-//        $attributes = $this->extractRelationshipAttributes($relationshipName, $attributes);
-//        $relationKey = $this->persist($factoryName, $attributes)->getKey();
 
         return $relationKey;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -139,6 +139,11 @@ class Builder
         return $entity;
     }
 
+    protected function ()
+    {
+        
+    }
+
     protected function existingIndex($name)
     {
         $indices = $this->model->allIndices($name);
@@ -296,7 +301,6 @@ class Builder
                 $entity[$columnName] = $this->fetchRelationId($relationship, $columnName, $attributes);
             }
         }
-
         return $entity;
     }
 
@@ -308,7 +312,7 @@ class Builder
      */
     protected function findRelation($attribute)
     {
-        if (is_string($attribute) && preg_match('/^factory:(.+)$/i', $attribute, $matches)) {
+        if (is_string($attribute) && (preg_match('/^factory:(.+)$/i', $attribute, $matches) || preg_match('/^model:(.+)$/i', $attribute, $matches))) {
 //            return $matches[1];
             return $matches;
         }
@@ -334,8 +338,11 @@ class Builder
                 $relationKey = $this->persist($factoryName[1], $attributes)->getKey();
                 break;
             case 'model:':
-//                $attributes = $this->extractRelationshipAttributes($relationshipName, $attributes);
-                $relationKey = $this->exists($relationshipName);
+                $attributes = $this->extractRelationshipAttributes($relationshipName, $attributes);
+                $relationKey = $this->existingIndex($factoryName[1]);
+                break;
+            default:
+                throw new \Exception('Relation identifier not allowed. Please use model or factory.');
         }
 //        $attributes = $this->extractRelationshipAttributes($relationshipName, $attributes);
 //        $relationKey = $this->persist($factoryName, $attributes)->getKey();

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -139,9 +139,25 @@ class Builder
         return $entity;
     }
 
-    protected function ()
+    protected function random($name, $overrides)
     {
-        
+        $attributes = $this->getAttributes($name, $overrides);
+        $class = $this->getFixture($name)->name;
+
+        // We'll pass off the process of creating the entity.
+        // That way, folks can use different persistence layers.
+
+        return $this->model->random($class, $attributes);
+    }
+
+    protected function exists($name, $attributes)
+    {
+        $entity = $this->random($name, $attributes);
+
+        $this->assignRelationships($entity, $attributes);
+        $this->model->save($entity);
+
+        return $entity;
     }
 
     protected function existingIndex($name)

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -64,4 +64,10 @@ class EloquentModel implements IsPersistable
         return $object;
     }
 
+    private function allIndices($type)
+    {
+        $object = new $type;
+        return $type->all()->get($object->primaryKey);
+    }
+
 }

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -64,10 +64,10 @@ class EloquentModel implements IsPersistable
         return $object;
     }
 
-    private function allIndices($type)
+    public function allIndices($type)
     {
         $object = new $type;
-        return $type->all()->get($object->primaryKey);
+        return $object->all()->lists($object->getKeyName())->toArray();
     }
 
 }

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -84,8 +84,11 @@ class EloquentModel implements IsPersistable
     {
         $object = new $type;
         $count = $type::count() - count($existingKeys);
-        $rand = mt_rand(0,$count-1);
-        return $object->whereNotIn($object->getKeyName(), $existingKeys)->get()[$rand];
+        if ($count > 0) {
+            $rand = mt_rand(0,$count-1);
+            return $object->whereNotIn($object->getKeyName(), $existingKeys)->get()[$rand];
+        }
+        return $object;
     }
 
 }

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -25,13 +25,13 @@ class EloquentModel implements IsPersistable
     }
 
 
-    public function random($type, array $attributes)
+    public function random($type, array $attributes, array $existingKeys)
     {
         if ( ! class_exists($type)) {
             throw new TestDummyException("The {$type} model was not found.");
         }
 
-        $model = $this->getRandom($type);
+        $model = $this->getRandom($type, $existingKeys);
 
         Eloquent::unguard();
         $model->fill($attributes);
@@ -80,12 +80,12 @@ class EloquentModel implements IsPersistable
         return $object;
     }
 
-    private function getRandom($type)
+    private function getRandom($type, array $existingKeys)
     {
         $object = new $type;
-        $count = $type::count();
+        $count = $type::count() - count($existingKeys);
         $rand = mt_rand(0,$count-1);
-        return $object->all()[$rand];
+        return $object->whereNotIn($object->getKeyName(), $existingKeys)->get()[$rand];
     }
 
 }

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -24,6 +24,16 @@ class EloquentModel implements IsPersistable
         return $this->fill($type, $attributes);
     }
 
+
+    public function random($type, array $attributes)
+    {
+        if ( ! class_exists($type)) {
+            throw new TestDummyException("The {$type} model was not found.");
+        }
+
+        return $this->getRandom($type);
+    }
+
     /**
      * Persist the entity.
      *
@@ -64,10 +74,12 @@ class EloquentModel implements IsPersistable
         return $object;
     }
 
-    public function allIndices($type)
+    private function getRandom($type)
     {
         $object = new $type;
-        return $object->all()->lists($object->getKeyName())->toArray();
+        $count = $type::count();
+        $rand = mt_rand(0,$count-1);
+        return $object->all()[$rand];
     }
 
 }

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -25,6 +25,14 @@ class EloquentModel implements IsPersistable
     }
 
 
+    /**
+     * Get a random entity and fill any override attributes
+     * @param $type
+     * @param array $attributes
+     * @param array $existingKeys
+     * @return mixed
+     * @throws TestDummyException
+     */
     public function random($type, array $attributes, array $existingKeys)
     {
         if ( ! class_exists($type)) {
@@ -80,6 +88,14 @@ class EloquentModel implements IsPersistable
         return $object;
     }
 
+    /**
+     * Fetch a random entity from the database which is not already in use
+     * If none exists, create a new one
+     *
+     * @param $type
+     * @param array $existingKeys
+     * @return mixed
+     */
     private function getRandom($type, array $existingKeys)
     {
         $object = new $type;

--- a/src/EloquentModel.php
+++ b/src/EloquentModel.php
@@ -31,7 +31,13 @@ class EloquentModel implements IsPersistable
             throw new TestDummyException("The {$type} model was not found.");
         }
 
-        return $this->getRandom($type);
+        $model = $this->getRandom($type);
+
+        Eloquent::unguard();
+        $model->fill($attributes);
+        Eloquent::reguard();
+
+        return $model;
     }
 
     /**

--- a/src/IsPersistable.php
+++ b/src/IsPersistable.php
@@ -31,6 +31,6 @@ interface IsPersistable
      */
     public function getAttributes($entity);
 
-    public function random($type, array $attributes);
+    public function random($type, array $attributes, array $existingKeys);
 
 }

--- a/src/IsPersistable.php
+++ b/src/IsPersistable.php
@@ -31,4 +31,6 @@ interface IsPersistable
      */
     public function getAttributes($entity);
 
+    public function random($type, array $attributes);
+
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -284,6 +284,14 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($posts[0]->author, $posts[1]->author);
     }
 
+    /** @test */
+    public function it_will_create_a_new_when_two_are_required_but_only_one_exists()
+    {
+        TestDummy::create('Person');    //We create 2 to ensure sender_id != receiver_id, since that will create an error
+        $message = TestDummy::create('message_between_existing_people');
+
+        $this->assertNotEquals($message->sender, $message->receiver);
+    }
 
 }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -64,8 +64,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $attributes = TestDummy::build('Post');
 
-        assertInstanceOf('Post', $attributes);
-        assertEquals('Post Title', $attributes->title);
+        $this->assertInstanceOf('Post', $attributes);
+        $this->assertEquals('Post Title', $attributes->title);
     }
 
     /** @test */
@@ -73,7 +73,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::build('Post', ['title' => 'override']);
 
-        assertEquals('override', $post->title);
+        $this->assertEquals('override', $post->title);
     }
 
     /** @test */
@@ -81,7 +81,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::build('scheduled_post');
 
-        assertInstanceOf('Post', $post);
+        $this->assertInstanceOf('Post', $post);
     }
 
     /** @test */
@@ -89,11 +89,11 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $comments = TestDummy::times(2)->create('Comment');
 
-        assertInstanceOf('Comment', $comments[0]);
-        assertInternalType('string', $comments[0]->body);
+        $this->assertInstanceOf('Comment', $comments[0]);
+        $this->assertInternalType('string', $comments[0]->body);
 
         // Faker should produce a unique value for each generation.
-        assertNotEquals($comments[0]->body, $comments[1]->body);
+        $this->assertNotEquals($comments[0]->body, $comments[1]->body);
     }
 
     /** @test */
@@ -101,8 +101,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $attributes = TestDummy::attributesFor('Post', ['title' => 'override']);
 
-        assertInternalType('array', $attributes);
-        assertEquals('override', $attributes['title']);
+        $this->assertInternalType('array', $attributes);
+        $this->assertEquals('override', $attributes['title']);
     }
 
     /** @test */
@@ -110,8 +110,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $post = TestDummy::create('Post');
 
-        assertInstanceOf('Post', $post);
-        assertNotNull($post->id);
+        $this->assertInstanceOf('Post', $post);
+        $this->assertNotNull($post->id);
     }
 
     /** @test */
@@ -119,8 +119,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $comment = TestDummy::create('Comment');
 
-        assertInstanceOf('Comment', $comment);
-        assertInstanceOf('Post', $comment->post);
+        $this->assertInstanceOf('Comment', $comment);
+        $this->assertInstanceOf('Post', $comment->post);
     }
 
     /** @test */
@@ -128,8 +128,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     {
         $posts = TestDummy::times(3)->create('Post');
 
-        assertInstanceOf('Illuminate\Support\Collection', $posts);
-        assertCount(3, $posts);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $posts);
+        $this->assertCount(3, $posts);
     }
 
     /**
@@ -154,7 +154,7 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.title' => 'override'
         ]);
 
-        assertEquals('override', $comment->post->title);
+        $this->assertEquals('override', $comment->post->title);
     }
 
     /** @test */
@@ -165,8 +165,8 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'receiver_id.name' => 'Jeffrey',
         ]);
 
-        assertEquals('Adam', $message->sender->name);
-        assertEquals('Jeffrey', $message->receiver->name);
+        $this->assertEquals('Adam', $message->sender->name);
+        $this->assertEquals('Jeffrey', $message->receiver->name);
     }
 
     /** @test */
@@ -178,9 +178,9 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.author_id.name' => 'Overridden Author Name',
         ]);
 
-        assertEquals('Overridden Comment Body', $comment->body);
-        assertEquals('Overridden Post Title', $comment->post->title);
-        assertEquals('Overridden Author Name', $comment->post->author->name);
+        $this->assertEquals('Overridden Comment Body', $comment->body);
+        $this->assertEquals('Overridden Post Title', $comment->post->title);
+        $this->assertEquals('Overridden Author Name', $comment->post->author->name);
     }
 
     /** @test */
@@ -191,9 +191,25 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'post_id.title' => 'override'
         ]);
 
-        assertNull($comment->post);
-        assertNull($comment->getAttribute('post_id.title'));
+        $this->assertNull($comment->post);
+        $this->assertNull($comment->getAttribute('post_id.title'));
     }
+
+    /* Tests for using existing data
+     * @author Leo "Phroggyy" Sjöberg <leo@rlstudio.se>
+     */
+
+    /** @test */
+    public function it_establishes_relationships_if_specified()
+    {
+        $post = TestDummy::create('Post');
+        $comment = TestDummy::create('comment_for_existing_post');
+
+        $this->assertInstanceOf('Comment', $comment);
+        $this->assertInstanceOf('Post', $comment->post);
+        $this->assertEquals($post->id, $comment->post->id);
+    }
+
 }
 
 function comment()

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -231,10 +231,6 @@ class FactoryTest extends PHPUnit_Framework_TestCase
             'receiver_id.name' => 'Jeffrey',
         ]);
 
-        /*
-         * If the test fails, run again, you ran into a collision
-         */
-
         $this->assertEquals('Adam', $message->sender->name);
         $this->assertEquals('Jeffrey', $message->receiver->name);
     }
@@ -266,6 +262,26 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Overridden Comment Body', $comment->body);
         $this->assertEquals('Overridden Post Title', $comment->post->title);
         $this->assertEquals('Overridden Author Name', $comment->post->author->name);
+    }
+
+    /** @test */
+    public function it_creates_models_if_no_existing_are_found()
+    {
+        $comment = TestDummy::create('comment_for_existing_post');
+
+        $this->assertInstanceOf('Comment', $comment);
+        $this->assertInstanceOf('Post', $comment->post);
+    }
+
+    /** @test */
+    public function it_can_create_and_persist_multiple_times_with_existing()
+    {
+        $posts = TestDummy::times(3)->create('post_by_existing_person');
+
+        $this->assertInstanceOf('Illuminate\Support\Collection', $posts);
+        $this->assertCount(3, $posts);
+        // Since we have no existing person the first time, it will be automatically created, but only once...
+        $this->assertEquals($posts[0]->author, $posts[1]->author);
     }
 
 

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -9,6 +9,11 @@ $factory('Post', [
     'title' => 'Post Title'
 ]);
 
+$factory('Post', 'post_by_existing_person', [
+    'author_id' => 'model:Person',
+    'title' => 'Post Title'
+]);
+
 $factory('Comment', function($faker) {
 
     return [
@@ -26,6 +31,11 @@ $factory('Comment', 'comment_for_post_by_person', [
 
 $factory('Comment', 'comment_for_existing_post', [
     'post_id' => 'model:Post',
+    'body' => $faker->word
+]);
+
+$factory('Comment', 'comment_for_existing_post_by_existing_person', [
+    'post_id' => 'model:post_by_existing_person',
     'body' => $faker->word
 ]);
 

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -41,6 +41,18 @@ $factory('Message', [
     'receiver_id' => 'factory:Person',
 ]);
 
+$factory('Message', 'message_between_existing_people', [
+    'contents' => $faker->sentence,
+    'sender_id' => 'model:Person',
+    'receiver_id' => 'model:Person',
+]);
+
+$factory('Message', 'message_between_existing_and_new_people', [
+    'contents' => $faker->sentence,
+    'sender_id' => 'factory:Person',
+    'receiver_id' => 'model:Person',
+]);
+
 $factory('Person', [
     'name' => $faker->name
 ]);

--- a/tests/support/factories/factories.php
+++ b/tests/support/factories/factories.php
@@ -24,6 +24,11 @@ $factory('Comment', 'comment_for_post_by_person', [
     'body' => $faker->word
 ]);
 
+$factory('Comment', 'comment_for_existing_post', [
+    'post_id' => 'model:Post',
+    'body' => $faker->word
+]);
+
 $factory('Foo', function($faker) {
     return [
         'name' => $faker->word


### PR DESCRIPTION
This resolves #97. Currently, the command for using existing data rather than new data is `model:factoryName`, as compared to the default `factory:factoryName`. If there is no existing data, an entry will be created in the same fashion as `factory:factoryName`.

This means that, given the following conditions (and assuming we have our relations correctly defined):

~~~
$factory('App\User', [
    'first_name'     => $faker->firstName,
    'last_name'     => $faker->lastName,
    'email'             => $faker->unique()->email,
    'password'      => bcrypt($faker->word),
]);

$factory('App\Post', 'post_with_existing_user', [
    'user_id'       => 'model:App\User',
    'title'                => $faker->sentence,
    'body'              => $faker->lastName,
]);
~~~

then

`Factory::create('post_with_existing_user');`  
Will produce a result identical to  
~~~
Factory::create('App\User');
Factory::create('post_with_existing_user');
~~~