### PR TITLE
Pass through override arguments to factory definition callback

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -152,7 +152,7 @@ class Builder
         $attributes = $this->filterRelationshipAttributes($attributes);
 
         $factory = $this->triggerFakerOnAttributes(
-            $this->getFixture($name)->attributes
+            $this->getFixture($name)->attributes, $attributes
         );
 
         return array_merge($factory, $attributes);
@@ -202,16 +202,17 @@ class Builder
      * Apply Faker dummy values to the attributes.
      *
      * @param  object|array $attributes
+     * @param  array        $overrides
      * @return array
      */
-    protected function triggerFakerOnAttributes($attributes)
+    protected function triggerFakerOnAttributes($attributes, array $overrides = [])
     {
         // If $attributes is a closure, then we need to call it
         // and fetch the returned array. This way, we ensure
         // that we always fetch unique faked values.
 
         if ($attributes instanceof Closure) {
-            $attributes = $attributes($this->faker());
+            $attributes = $attributes($this->faker(), $overrides);
         }
 
         // To ensure that we don't use the same Faker value for every


### PR DESCRIPTION
This edit simply passes through any arguments provided during factory calls, i.e ...
```
Factory::method('Model', $overrides);
```
... on to the factory definition callback, if provided:
```
$factory('Model', function($faker, $overrides) {
    ...
});
```
... or an empty array by default.

This allows for customising factory behaviour and conditionally creating relational models within the factory definition callback.

This also opens up the door for creating more complex generators in the callback, that can perform custom logic based on the passed $overrides data.