### PR TITLE
Switch to fakerphp/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~4.0|~5.0|~6.0|~7.0|~8.0",
-        "fzaninotto/faker": "~1.4"
+        "fakerphp/faker": "^1.9.1"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
This package is no longer working in new versions, since fzaninotto/faker is no longer supported and Laravel moved to fakerphp/faker.